### PR TITLE
Fixes for Static Vector and Singly Linked List

### DIFF
--- a/FixedVector_main.cpp
+++ b/FixedVector_main.cpp
@@ -3,6 +3,9 @@
 
 #include "FixedVector.hpp"
 using std::cout;
+using std::string;
+using std::ostream;
+using std::endl;
 
 class Student {
 private:

--- a/SinglyLinkedList.hpp
+++ b/SinglyLinkedList.hpp
@@ -102,6 +102,7 @@ void SinglyLinkedList<T>::removeAfter(Node<T>* curNode) {
   // Special case, remove head
   if (curNode == nullptr && head != nullptr) {
      Node<T> *sucNode = head->next;
+     delete head;
      head = sucNode;
 
      if (sucNode == nullptr) { // Removed last item
@@ -110,6 +111,7 @@ void SinglyLinkedList<T>::removeAfter(Node<T>* curNode) {
   }
   else if (curNode->next != nullptr) {
      Node<T> *sucNode = curNode->next->next;
+     delete curNode->next;
      curNode->next = sucNode;
 
      if (sucNode == nullptr) { // Removed tail


### PR DESCRIPTION
## What were the issues?
1. `FixedVector_main.cpp` did not specify that string, ostream, and endl belonged to the std namespace
2. `SinglyLinkedList.hpp` did not delete nodes upon `removeAfter(Node<T>*)` being called. This created memory leaks

## How were the issues fixed?
1. Imported the missing identifiers in `FixedVector_main.cpp`
2. Deleted the nodes that were intended to be deleted in the `removeAfter(Node<T>*)` function from `SinglyLinkedList.hpp`